### PR TITLE
Some fixes

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ url="https://github.com/cpp-io2d/"
 license=('boost')
 depends=('boost-libs' 'cairo' 'libpng')
 #optdepends=('')
-makedepends=('git' 'cmake' 'boost' 'graphicsmagick' 'cairomm' 'libpng')
+makedepends=('git' 'cmake' 'boost' 'graphicsmagick' 'cairomm' 'libpng' 'libsigsegv')
 source=('git+https://github.com/cpp-io2d/P0267_RefImpl.git'
 				'libpngPatch.diff'
 				'sigsegv.diff')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,6 +4,7 @@ pkgrel=1
 pkgdesc="P0267 Reference Implementation - A Proposal to add 2d Rendering and Display to C++"
 arch=('x86_64')
 url="https://github.com/cpp-io2d/"
+options=('!lto')
 license=('boost')
 depends=('boost-libs' 'cairo' 'libpng')
 #optdepends=('')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -31,24 +31,17 @@ build() {
 	# Fix the compile error caused by the missing header
 	patch ./P0267_RefImpl/Tests/main.cpp ../sigsegv.diff
 
-	# Update submodule for external/svgpp
-	#   Boost 1.71.0 and up broke broke the version of svgpp that
-	#     this this is pinned to. Switching to 1.3.0 should fix
-	# https://github.com/cpp-io2d/P0267_RefImpl/issues/136
-	#  and its parent issue
-	#  https://github.com/svgpp/svgpp/issues/79
-	cd ./P0267_RefImpl/Samples/svg/external/svgpp
-	git checkout v1.3.0
-	cd "$srcdir/$_gitdir"
-
-	mkdir build -p
-	cd build
-	cmake .. -DCMAKE_INSTALL_PREFIX=usr
-	cmake --build .
+	cmake -B build -S "." \
+		-DCMAKE_BUILD_TYPE='None' \
+                -DCMAKE_INSTALL_PREFIX='/usr' \
+                -DCMAKE_INSTALL_LIBDIR=lib \
+                -Wno-dev \
+                -DIO2D_WITHOUT_SAMPLES=1
+	cmake --build build
 }
 
 package() {
-	cd "$srcdir/$_gitdir/build"
-	cmake --install . --prefix="${pkgdir}/usr"
+        cd "$_gitdir"
+        DESTDIR="$pkgdir" cmake --install build
 }
 


### PR DESCRIPTION
I had to build io2d recently and had some issues with it, so I decided to fix this PKGBUILD.

List of changes:
- Fix missing `libsigsegv` since you added the missing header but didn't include it in deps
- Change build & install to more follow the [Arch's cmake package guideline](https://wiki.archlinux.org/title/CMake_package_guidelines)
- Build without samples
- Disable LTO. I had some trouble trying to build something else with io2d with lto enabled (makepkg does it by default)